### PR TITLE
💄 ui: 공고 카드 컴포넌트 구현

### DIFF
--- a/app/(route)/(alba)/announce-list/_components/AnnounceCard.tsx
+++ b/app/(route)/(alba)/announce-list/_components/AnnounceCard.tsx
@@ -1,0 +1,37 @@
+import Image from "next/image";
+import React from "react";
+import clock from "@/public/icons/clock.png";
+import mapPin from "@/public/icons/map-pin.png";
+import arrowUpRed40 from "@/public/icons/arrow-up-red-40.png";
+
+export default function AnnounceCard() {
+  return (
+    <div className="h-[261px] w-[171px] rounded-[12px] border border-gray-20 bg-white p-3 md:h-[349px] md:w-[313px]">
+      <div className="h-[82px] w-[147px] rounded-[12px] md:h-[160px] md:w-[280px]">이미지</div>
+      <p className="py-2 font-bold md:text-l">식당이름</p>
+      <div className="flex items-start gap-1">
+        <div className="h-4 w-4">
+          <Image src={clock} alt="시간" />
+        </div>
+        <p className="text-s text-gray-50 md:text-m">
+          2023-01-02 <br className="md:hidden" /> 15:00~18:00 (3시간)
+        </p>
+      </div>
+      <div className="flex items-center gap-1">
+        <div className="h-4 w-4">
+          <Image src={mapPin} alt="장소" />
+        </div>
+        <p className="py-2 text-s text-gray-50 md:text-m">서울시 강남구</p>
+      </div>
+      <div className="flex flex-col md:flex-row md:gap-4 md:py-4">
+        <p className="text-ml pt-1 font-bold md:text-xl">10,000원</p>
+        <p className="text-primary flex items-center text-s">
+          기존 시급보다 50%
+          <div className="h-4 w-4">
+            <Image src={arrowUpRed40} alt="up" />
+          </div>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/(route)/(alba)/announce-list/_components/announce-card/index.tsx
+++ b/app/(route)/(alba)/announce-list/_components/announce-card/index.tsx
@@ -24,13 +24,13 @@ export default function AnnounceCard() {
         <p className="py-2 text-s text-gray-50 md:text-m">서울시 강남구</p>
       </div>
       <div className="flex flex-col md:flex-row md:gap-4 md:py-4">
-        <p className="text-ml pt-1 font-bold md:text-xl">10,000원</p>
-        <p className="text-primary flex items-center text-s">
+        <p className="pt-1 font-bold text-ml md:text-xl">10,000원</p>
+        <div className="flex items-center text-s text-primary">
           기존 시급보다 50%
           <div className="h-4 w-4">
             <Image src={arrowUpRed40} alt="up" />
           </div>
-        </p>
+        </div>
       </div>
     </div>
   );

--- a/app/(route)/(alba)/announce-list/_components/announce-card/index.tsx
+++ b/app/(route)/(alba)/announce-list/_components/announce-card/index.tsx
@@ -10,26 +10,26 @@ export default function AnnounceCard() {
       <div className="h-[82px] w-[147px] rounded-[12px] md:h-[160px] md:w-[280px]">이미지</div>
       <data className="py-2 font-bold md:text-l">식당이름</data>
       <div className="flex items-start gap-1">
-        <picture className="h-4 w-4">
+        <div className="h-4 w-4">
           <Image src={clock} alt="시간" />
-        </picture>
+        </div>
         <time className="text-s text-gray-50 md:text-m">
           2023-01-02 <br className="md:hidden" /> 15:00~18:00 (3시간)
         </time>
       </div>
       <div className="flex items-center gap-1">
-        <picture className="h-4 w-4">
+        <div className="h-4 w-4">
           <Image src={mapPin} alt="장소" />
-        </picture>
+        </div>
         <data className="py-2 text-s text-gray-50 md:text-m">서울시 강남구</data>
       </div>
       <div className="flex flex-col md:flex-row md:gap-4 md:py-4">
         <data className="pt-1 font-bold text-ml md:text-xl">10,000원</data>
         <div className="flex items-center text-s text-primary">
           기존 시급보다 50%
-          <picture className="h-4 w-4">
+          <div className="h-4 w-4">
             <Image src={arrowUpRed40} alt="up" />
-          </picture>
+          </div>
         </div>
       </div>
     </article>

--- a/app/(route)/(alba)/announce-list/_components/announce-card/index.tsx
+++ b/app/(route)/(alba)/announce-list/_components/announce-card/index.tsx
@@ -6,32 +6,32 @@ import arrowUpRed40 from "@/public/icons/arrow-up-red-40.png";
 
 export default function AnnounceCard() {
   return (
-    <div className="h-[261px] w-[171px] rounded-[12px] border border-gray-20 bg-white p-3 md:h-[349px] md:w-[313px]">
+    <article className="h-[261px] w-[171px] rounded-[12px] border border-gray-20 bg-white p-3 md:h-[349px] md:w-[313px]">
       <div className="h-[82px] w-[147px] rounded-[12px] md:h-[160px] md:w-[280px]">이미지</div>
-      <p className="py-2 font-bold md:text-l">식당이름</p>
+      <data className="py-2 font-bold md:text-l">식당이름</data>
       <div className="flex items-start gap-1">
-        <div className="h-4 w-4">
+        <picture className="h-4 w-4">
           <Image src={clock} alt="시간" />
-        </div>
-        <p className="text-s text-gray-50 md:text-m">
+        </picture>
+        <time className="text-s text-gray-50 md:text-m">
           2023-01-02 <br className="md:hidden" /> 15:00~18:00 (3시간)
-        </p>
+        </time>
       </div>
       <div className="flex items-center gap-1">
-        <div className="h-4 w-4">
+        <picture className="h-4 w-4">
           <Image src={mapPin} alt="장소" />
-        </div>
-        <p className="py-2 text-s text-gray-50 md:text-m">서울시 강남구</p>
+        </picture>
+        <data className="py-2 text-s text-gray-50 md:text-m">서울시 강남구</data>
       </div>
       <div className="flex flex-col md:flex-row md:gap-4 md:py-4">
-        <p className="pt-1 font-bold text-ml md:text-xl">10,000원</p>
+        <data className="pt-1 font-bold text-ml md:text-xl">10,000원</data>
         <div className="flex items-center text-s text-primary">
           기존 시급보다 50%
-          <div className="h-4 w-4">
+          <picture className="h-4 w-4">
             <Image src={arrowUpRed40} alt="up" />
-          </div>
+          </picture>
         </div>
       </div>
-    </div>
+    </article>
   );
 }

--- a/app/(route)/(alba)/announce-list/page.tsx
+++ b/app/(route)/(alba)/announce-list/page.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import AnnounceCard from "./_components/AnnounceCard";
+import AnnounceCard from "./_components/announce-card";
 
 export default function page() {
   return (

--- a/app/(route)/(alba)/announce-list/page.tsx
+++ b/app/(route)/(alba)/announce-list/page.tsx
@@ -1,5 +1,12 @@
 import React from "react";
+import AnnounceCard from "./_components/AnnounceCard";
 
 export default function page() {
-  return <div>announce-list</div>;
+  return (
+    <div>
+      <h2 className="font-bold text-2xl">맞춤 공고</h2>
+      <AnnounceCard />
+      <h2 className="font-bold text-2xl">전체 공고</h2>
+    </div>
+  );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,6 +15,7 @@ const config: Config = {
         s: "12px ",
         m: "14px",
         base: "16px",
+        ml: "18px",
         l: "20px",
         xl: "24px",
         "2xl": "28px",


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 <!-- 이슈 번호 입력 -->

- close #19 

## 🧱 작업 사항
공고 카드 컴포넌트 구현

## 📸 결과물
![chrome-capture-2024-5-22](https://github.com/902z/gheupPAY/assets/88658551/056a7024-1ce1-4308-a1c3-c6db1e0e4620)

## 💬 공유 포인트 및 논의 사항
기존시급%는 공통 컴포넌트로 구현 후에 추가할 예정입니다. 