### PR TITLE
📦 chore: 전체 페이지 컨테이너 컴포넌트 적용

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <main className="mx-3 mt-[102px] min-h-screen md:mx-8 md:mt-[70px] lg:mx-auto lg:max-w-[964px]">
+        <main className="mx-3 min-h-screen pt-[102px] md:mx-8 md:pt-[70px] lg:mx-auto lg:max-w-[964px]">
           {children}
         </main>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,9 +14,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <main className="mx-3 mb-[126px] mt-[102px] md:mx-8 md:mb-[100px] md:mt-[70px] lg:mx-auto lg:max-w-[964px]">
-          {children}
-        </main>
+        <main className="mx-3 mt-[102px] md:mx-8 md:mt-[70px] lg:mx-auto lg:max-w-[964px]">{children}</main>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <main className="mx-3 min-h-screen pt-[102px] md:mx-8 md:pt-[70px] lg:mx-auto lg:max-w-[964px]">
+        <main className="min-h-screen w-full px-3 pt-[102px] md:px-8 md:pt-[70px] lg:mx-auto lg:max-w-[964px] lg:px-0">
           {children}
         </main>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,9 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <main className="mx-3 mt-[102px] md:mx-8 md:mt-[70px] lg:mx-auto lg:max-w-[964px]">{children}</main>
+        <main className="mx-3 mt-[102px] min-h-screen md:mx-8 md:mt-[70px] lg:mx-auto lg:max-w-[964px]">
+          {children}
+        </main>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body>
+        <main className="mx-3 mb-[126px] mt-[102px] md:mx-8 md:mb-[100px] md:mt-[70px] lg:mx-auto lg:max-w-[964px]">
+          {children}
+        </main>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## 🏷️ #29 

- close #29 

## 🧱 작업 사항

전체 페이지에 적용할 수 있는 컨테이너 컴포넌트입니다.

layout에 추가했으니 페이지에서 전체 레이아웃은 너비 신경 안쓰셔도 됩니다!

헤더가 position: fixed로 놓일 수도 있을 것 같아서 margin-top을 달아놨습니다.

## 📸 결과물
![image](https://github.com/902z/gheupPAY/assets/86544979/560a3bc4-1a72-4b7a-ad35-8e4b077f1afb)
![image](https://github.com/902z/gheupPAY/assets/86544979/7698387b-e2e4-4ea3-bd35-1b4c5ac47ef7)

## 💬 공유 포인트 및 논의 사항