### PR TITLE
✨  feat: 모달 스크롤 막기

### DIFF
--- a/app/_components/button/index.tsx
+++ b/app/_components/button/index.tsx
@@ -24,11 +24,12 @@ const BUTTON =
  * className을 통해 추가적인 스타일을 입혀야 합니다.
  * @param children : 버튼 안에 담을 내용을 적습니다. (ex. "버튼")
  * @param className : 추가적인 css를 넣습니다. 넓이, 폰트 관련 css는 무조건 넣어야 합니다.
- * @param color : 버튼의 색상 스타일을 결정합니다. (orange, white)
+ * @param btnColor : 버튼의 색상 스타일을 결정합니다. (orange, white)
+ * @param btnType : 버튼의 타입을 결정합니다. (button, submit)
  * @returns 버튼 컴포넌트를 반환합니다.
  * @example
- * <Button className="w-8 text-xl" color="orange">버튼</Button>
- * <Button className="w-6 text-xl" color="white">버튼</Button>
+ * <Button className="w-8 text-xl" btnColor="orange" btnType="submit" >제출</Button>
+ * <Button className="w-6 text-xl" btnColor="white">버튼</Button>
  */
 export default function Button({
   children,

--- a/app/_components/modals/_components/confirm-modal.tsx
+++ b/app/_components/modals/_components/confirm-modal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Button from "../../button";
+import { createPortal } from "react-dom";
 
 
 type ModalProps = {
@@ -36,7 +37,7 @@ export default function ConfirmModal({
     }
   };
 
-  return (
+  return createPortal(
     <AnimatePresence>
       <motion.div
         initial={{ opacity: 0 }}
@@ -57,13 +58,14 @@ export default function ConfirmModal({
             <Button
               onClick={handleBtn}
               className="mx-24 flex h-[42px] items-center justify-center rounded-[8px] font-bold md:mx-0 md:h-[48px] md:w-[120px]"
-              color="orange"
+              btnColor="orange"
             >
               확인
             </Button>
           </div>
         </motion.div>
       </motion.div>
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/app/_components/modals/_components/select-modal.tsx
+++ b/app/_components/modals/_components/select-modal.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import Button from "../../button";
 import check from "@/public/icons/check.png";
 import Image from "next/image";
-
+import { createPortal } from "react-dom";
 
 type ModalProps = {
   closeModal: () => void;
@@ -59,7 +59,7 @@ export default function SelectModal({
       onClickNo();
     }
   };
-  return (
+  return createPortal(
     <AnimatePresence>
       <motion.div
         initial={{ opacity: 0 }}
@@ -83,20 +83,21 @@ export default function SelectModal({
             <Button
               onClick={handleNoBtn}
               className="flex h-[42px] items-center justify-center rounded-[8px] font-bold md:h-[48px] md:w-[120px]"
-              color="white"
+              btnColor="white"
             >
               아니오
             </Button>
             <Button
               onClick={handleYesBtn}
               className="flex h-[42px] items-center justify-center rounded-[8px] font-bold md:h-[48px] md:w-[120px]"
-              color="orange"
+              btnColor="orange"
             >
               {YES_TYPE[yesType]}
             </Button>
           </div>
         </motion.div>
       </motion.div>
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body,
   );
 }

--- a/app/_components/modals/_components/warning-modal.tsx
+++ b/app/_components/modals/_components/warning-modal.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import Button from "../../button";
 import warning from "@/public/icons/warning.png";
 import Image from "next/image";
-
+import { createPortal } from "react-dom";
 
 type ModalProps = {
   closeModal: () => void;
@@ -39,7 +39,7 @@ export default function WarningModal({
     }
   };
 
-  return (
+  return createPortal(
     <AnimatePresence>
       <motion.div
         initial={{ opacity: 0 }}
@@ -64,13 +64,14 @@ export default function WarningModal({
             <Button
               onClick={handleBtn}
               className="mx-24 flex h-[42px] items-center justify-center rounded-[8px] font-bold md:mx-0 md:h-[48px] md:w-[120px]"
-              color="white"
+              btnColor="white"
             >
               확인
             </Button>
           </div>
         </motion.div>
       </motion.div>
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body,
   );
 }

--- a/app/_hooks/use-modal.ts
+++ b/app/_hooks/use-modal.ts
@@ -15,10 +15,12 @@ export default function useModal() {
 
   const openModal = () => {
     setIsOpen(true);
+    document.querySelector("html")?.classList.add("scroll-locked");
   };
 
   const closeModal = () => {
     setIsOpen(false);
+    document.querySelector("html")?.classList.remove("scroll-locked");
   };
 
   return {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
   return (
     <>
       <div className="base-container flex flex-col text-center">
-        <Link href="/announce-list">리스트 페이지로 이동</Link>
+        <Link href="/notice-list">리스트 페이지로 이동</Link>
         <h1 className="font-bold">
           폰트를 굵게 하고 싶으면 font-bold를 쓰세요.
         </h1>
@@ -39,7 +39,6 @@ export default function Home() {
         <OpenModal warning modalContents="클나!">
           <button>경고하기</button>
         </OpenModal>
-        왜 프리뷰가 안 뜨지
       </div>
     </>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -80,3 +80,7 @@ input:-webkit-autofill {
   background: gray;
   border-radius: 5px;
 }
+
+.scroll-locked {
+  overflow: hidden;
+}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 <!-- 이슈 번호 입력 -->

- close #78 

## 🧱 작업 사항

- 모달을 띄웠을 때 뒷배경 스크롤 막았습니다.
- 모달을 돔을 수정했습니다. 이제 main 태그 안이 아니라 body 태그 직계 자손으로 열립니다.
- 왜 그랬냐면 그냥 해보고 싶어서 했습니다.
- 모달에 공용 버튼을 사용했는데 최근 사용법이 바뀌어서 그에 맞게 수정했습니다.
  

## 📸 결과물

## 💬 공유 포인트 및 논의 사항
