### PR TITLE
✨ feat: 테이블 페이지네이션 적용

### DIFF
--- a/app/(route)/(alba)/profile-detail/_components/notice-application-table/index.tsx
+++ b/app/(route)/(alba)/profile-detail/_components/notice-application-table/index.tsx
@@ -1,19 +1,38 @@
+"use client";
 import { UserApplication } from "@/app/_apis/type";
-import React from "react";
+import React, { useEffect } from "react";
 import AlbaStatusLabel from "../alba-status-label";
 import { calculateTimeRange } from "@/app/_util/calculate-time-range";
 import { dateFormat } from "@/app/_util/date-format";
 import formattedNumber from "@/app/_util/number-format";
+import Pagination from "@/app/_components/pagination";
 
 type NoticeApplicationTableProps = {
   applicationNotice: UserApplication;
+  activePage: number;
+  itemsCountPerPage: number;
 };
+
+const APPLICATION_LIST_ID = "application-list";
 
 export default function NoticeApplicationTable({
   applicationNotice,
+  activePage,
+  itemsCountPerPage,
 }: NoticeApplicationTableProps) {
+  const totalItemsCount = applicationNotice.count;
+
+  useEffect(() => {
+    if (window.location.hash) {
+      const element = document.querySelector(window.location.hash);
+      if (element) {
+        element.scrollIntoView({ behavior: "smooth" });
+      }
+    }
+  }, []);
+
   return (
-    <>
+    <div id={APPLICATION_LIST_ID}>
       <div className="overflow-auto rounded-xl shadow-md">
         <table className="w-full table-auto border-collapse border-spacing-0 border-gray-20">
           <thead>
@@ -53,7 +72,15 @@ export default function NoticeApplicationTable({
             ))}
           </tbody>
         </table>
+        <div className="my-2">
+          <Pagination
+            activePage={activePage}
+            totalItemsCount={totalItemsCount}
+            itemsCountPerPage={itemsCountPerPage}
+            focusHash={APPLICATION_LIST_ID}
+          />
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/app/(route)/(alba)/profile-detail/page.tsx
+++ b/app/(route)/(alba)/profile-detail/page.tsx
@@ -4,14 +4,31 @@ import { getUser } from "@/app/_apis/user";
 import UserProfile from "./_components/user-profile";
 import { getUserNoticeApplication } from "@/app/_apis/application";
 import NoticeApplicationTable from "./_components/notice-application-table";
+
 export const metadata = {
   title: "프로필 상세",
 };
-export default async function page() {
+
+type PageProps = {
+  searchParams: {
+    page?: string;
+  };
+};
+
+export default async function page({ searchParams }: PageProps) {
   const userId = "309aaf62-068e-4deb-a6c3-a31abacfdc67";
+
+  const page = parseInt(searchParams.page || "1", 10);
+  const limit = 10;
+  const offset = (page - 1) * limit;
+
   const userProfile = await getUser(userId);
 
-  const applicationNotice = await getUserNoticeApplication(userId);
+  const applicationNotice = await getUserNoticeApplication(
+    userId,
+    offset,
+    limit,
+  );
 
   return (
     <div className="base-container">
@@ -23,7 +40,11 @@ export default async function page() {
       </div>
       <h2 className="py-8 font-bold text-l md:text-2xl">신청 내역</h2>
       {/* <NoneApplication /> */}
-      <NoticeApplicationTable applicationNotice={applicationNotice} />
+      <NoticeApplicationTable
+        applicationNotice={applicationNotice}
+        activePage={page}
+        itemsCountPerPage={limit}
+      />
     </div>
   );
 }

--- a/app/(route)/admin/notice-detail/[notice_id]/page.tsx
+++ b/app/(route)/admin/notice-detail/[notice_id]/page.tsx
@@ -3,16 +3,33 @@ import { getShopNoticeDetail } from "@/app/_apis/shop";
 import NoticeDetailCard from "@/app/_components/notice-detail-card";
 import AlbaApplicationTable from "../_components/alba-application-table";
 import { getNoticeApplications } from "@/app/_apis/application";
+
 export const metadata = {
   title: "공고 상세",
 };
-export default async function page() {
+
+type PageProps = {
+  searchParams: {
+    page?: string;
+  };
+};
+
+export default async function page({ searchParams }: PageProps) {
   const shopId = "4490151c-5217-4157-b072-9c37b05bed47";
   const noticeId = "99996477-82db-4bda-aae1-4044f11d9a8b";
 
+  const page = parseInt(searchParams.page || "1", 10);
+  const limit = 10;
+  const offset = (page - 1) * limit;
+
   const noticeDetail = await getShopNoticeDetail(shopId, noticeId);
 
-  const applicationList = await getNoticeApplications(shopId, noticeId);
+  const applicationList = await getNoticeApplications(
+    shopId,
+    noticeId,
+    offset,
+    limit,
+  );
 
   return (
     <div className="base-container">
@@ -20,7 +37,11 @@ export default async function page() {
 
       <div className="my-12">
         <h2 className="py-8 font-bold text-l md:text-2xl">신청자 목록</h2>
-        <AlbaApplicationTable applicationList={applicationList} />
+        <AlbaApplicationTable
+          applicationList={applicationList}
+          activePage={page}
+          itemsCountPerPage={limit}
+        />
       </div>
     </div>
   );

--- a/app/(route)/admin/notice-detail/_components/alba-application-table/index.tsx
+++ b/app/(route)/admin/notice-detail/_components/alba-application-table/index.tsx
@@ -1,16 +1,35 @@
+"use client";
 import { GetShopsShopIdNoticesNoticeIdApplications } from "@/app/_apis/type";
-import React from "react";
+import React, { useEffect } from "react";
 import StatusLabel from "../status-label";
+import Pagination from "@/app/_components/pagination";
 
 type AlbaApplicationTableProps = {
   applicationList: GetShopsShopIdNoticesNoticeIdApplications;
+  activePage: number;
+  itemsCountPerPage: number;
 };
+
+const APPLICATION_LIST_ID = "application-list";
 
 export default function AlbaApplicationTable({
   applicationList,
+  activePage,
+  itemsCountPerPage,
 }: AlbaApplicationTableProps) {
+  const totalItemsCount = applicationList.count;
+
+  useEffect(() => {
+    if (window.location.hash) {
+      const element = document.querySelector(window.location.hash);
+      if (element) {
+        element.scrollIntoView({ behavior: "smooth" });
+      }
+    }
+  }, []);
+
   return (
-    <>
+    <div id={APPLICATION_LIST_ID}>
       <div className="overflow-auto rounded-xl shadow-md">
         <table className="w-full table-auto border-collapse border-spacing-0 border-gray-20">
           <thead>
@@ -42,7 +61,15 @@ export default function AlbaApplicationTable({
             ))}
           </tbody>
         </table>
+        <div className="my-2">
+          <Pagination
+            activePage={activePage}
+            totalItemsCount={totalItemsCount}
+            itemsCountPerPage={itemsCountPerPage}
+            focusHash={APPLICATION_LIST_ID}
+          />
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/app/_apis/application/index.ts
+++ b/app/_apis/application/index.ts
@@ -20,9 +20,15 @@ export async function getNoticeApplications(
 }
 
 // 유저의 지원 목록 조회
-export async function getUserNoticeApplication(user_id: string) {
+export async function getUserNoticeApplication(
+  user_id: string,
+  offset = 0,
+  limit = 10,
+) {
   try {
-    const res = await instance.get(`/users/${user_id}/applications`);
+    const res = await instance.get(
+      `/users/${user_id}/applications?offset=${offset}&limit=${limit}`,
+    );
     return res.data;
   } catch (error) {
     console.error("getUserNoticeApplication 함수에서 오류 발생:", error);

--- a/app/_apis/application/index.ts
+++ b/app/_apis/application/index.ts
@@ -5,10 +5,12 @@ import { GetShopsShopIdNoticesNoticeIdApplications } from "../type";
 export async function getNoticeApplications(
   shop_id: string,
   notice_id: string,
+  offset = 0,
+  limit = 10,
 ): Promise<GetShopsShopIdNoticesNoticeIdApplications> {
   try {
     const res = await instance.get<GetShopsShopIdNoticesNoticeIdApplications>(
-      `/shops/${shop_id}/notices/${notice_id}/applications`,
+      `/shops/${shop_id}/notices/${notice_id}/applications?offset=${offset}&limit=${limit}`,
     );
     return res.data;
   } catch (error) {

--- a/app/_components/pagination/index.tsx
+++ b/app/_components/pagination/index.tsx
@@ -77,7 +77,7 @@ export default function Pagination({
       </Link>
       {paginationList.map((page) => (
         <Link
-          className={` ${activePage === page ? "bg-red-30 text-white" : ""} flex h-10 w-10 items-center justify-center rounded-sm`}
+          className={` ${activePage === page ? "bg-red-30 text-white" : ""} flex h-10 w-10 items-center justify-center rounded-sm hover:bg-red-10 hover:text-black`}
           key={page}
           href={creatPageURL(page)}
         >


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 <!-- 이슈 번호 입력 -->

- close #112 

## 🧱 작업 사항
기존 테이블에 페이지네이션 적용했습니다. 총 두 군데이고, 공통 컴포넌트로 빼기 좀 어려운데 같이 고민해주세요..
## 📸 결과물
![image](https://github.com/902z/gheupPAY/assets/88658551/cb589af3-a553-4f39-8d62-7b956cf153d1)
![image](https://github.com/902z/gheupPAY/assets/88658551/200b24e3-8014-44bb-93a8-3ec6962d5f96)

## 💬 공유 포인트 및 논의 사항
테이블 쓰이는 곳 총 두 군데이고, 공통 컴포넌트로 빼기 좀 어려운데 같이 고민해주세요..
공컴을 빼면 th 부분 배열로 받아서 맵핑하고, td 부분 각각 프롭스받아서 맵핑을 돌립니다. 근데 맵핑을하면 첫번째 컬럼 고정이 절대 안돼요.,,.어떻게 해야할까요..