### PR TITLE
🐛  fix: 로그아웃 쿠키 주소도 삭제

### DIFF
--- a/app/_actions/index.ts
+++ b/app/_actions/index.ts
@@ -7,6 +7,7 @@ export async function logout() {
   await deleteCookie("accessToken");
   await deleteCookie("userId");
   await deleteCookie("type");
+  await deleteCookie("address");
   redirect("/");
 }
 


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 <!-- 이슈 번호 입력 -->

- close #121 

## 🧱 작업 사항

로그아웃 시 쿠키에 담긴 주소도 삭제

로그아웃 했을 때 주소가 남아서 맞춤공고가 제공되는 버그가 있었습니다.

이제 로그인 했다가 로그아웃 하면 맞춤공고는 제공되지 않습니다.


## 📸 결과물

## 💬 공유 포인트 및 논의 사항
