### PR TITLE
🐛  fix: 필터 모바일 꽉

### DIFF
--- a/app/(route)/(alba)/notice-list/_components/filter/index.tsx
+++ b/app/(route)/(alba)/notice-list/_components/filter/index.tsx
@@ -116,110 +116,104 @@ export default function Filter({ onClose, keyword }: FilterProps) {
 
   return (
     <>
-      <form>
-        <div className="absolute right-[-4px] z-20 mt-[8px] w-[390px] rounded-[10px] border border-gray-20 bg-white px-[20px] py-[24px] shadow">
-          <div className="mb-[24px] flex justify-between font-bold text-l">
-            <h2>상세 필터</h2>
-            <div className="h-[24px] w-[24px]">
-              <Image
-                className="cursor-pointer"
-                src={close}
-                alt="닫기"
-                width={24}
-                onClick={onClose}
-              />
-            </div>
+      <form className="fixed inset-0 z-50 overflow-y-scroll rounded-[10px] border border-gray-20 bg-white px-[20px] py-[24px] shadow md:absolute md:left-[-315px] md:top-[37px] md:h-[845px] md:w-[390px]">
+        <div className="mb-[24px] flex justify-between font-bold text-l">
+          <h2>상세 필터</h2>
+          <div className="h-[24px] w-[24px]">
+            <Image
+              className="cursor-pointer"
+              src={close}
+              alt="닫기"
+              width={24}
+              onClick={onClose}
+            />
           </div>
-          <div className="w-[350px] border-b pb-[24px]">
-            <h3>위치</h3>
-            <ul className="my-[12px] grid h-[258px] w-[350px] grid-cols-2 overflow-scroll overflow-x-hidden rounded-[6px] border border-gray-20 px-[28px] pb-[20px] text-m">
-              {ADDRESS.map((address) => (
-                <li className="grid grid-cols-2 text-m" key={address}>
-                  <data
-                    className="mt-[20px] w-[94px] cursor-pointer"
-                    onClick={() => handleAddressClick(address)}
-                  >
+        </div>
+        <div className="w-full min-w-[350px] border-b pb-[24px]">
+          <h3>위치</h3>
+          <ul className="my-[12px] grid h-[258px] w-full grid-cols-2 overflow-scroll overflow-x-hidden rounded-[6px] border border-gray-20 px-[28px] pb-[20px] text-m">
+            {ADDRESS.map((address) => (
+              <li className="grid grid-cols-2 text-m" key={address}>
+                <data
+                  className="mt-[20px] w-[94px] cursor-pointer"
+                  onClick={() => handleAddressClick(address)}
+                >
+                  {address}
+                </data>
+              </li>
+            ))}
+          </ul>
+          <div>
+            <ul className="flex flex-wrap gap-[8px]">
+              {selectedAddresses.map((address) => (
+                <li key={address}>
+                  <label className="flex justify-between gap-[4px] rounded-[20px] bg-red-10 px-[10px] py-[6px] text-m text-red-40">
+                    <input
+                      className="hidden"
+                      type="checkbox"
+                      name="address"
+                      value={address}
+                      checked
+                      onChange={() => handleAddressClick(address)}
+                    />
                     {address}
-                  </data>
+                    <Image
+                      className="mt-[2px] h-[16px] w-[16px] cursor-pointer"
+                      src={closeRed40}
+                      alt="닫기"
+                      width={24}
+                      onClick={() => handleRemoveAddressClick(address)}
+                    />
+                  </label>
                 </li>
               ))}
             </ul>
-            <div>
-              <ul className="flex flex-wrap gap-[8px]">
-                {selectedAddresses.map((address) => (
-                  <li key={address}>
-                    <label className="flex justify-between gap-[4px] rounded-[20px] bg-red-10 px-[10px] py-[6px] text-m text-red-40">
-                      <input
-                        className="hidden"
-                        type="checkbox"
-                        name="address"
-                        value={address}
-                        checked
-                        onChange={() => handleAddressClick(address)}
-                      />
-                      {address}
-                      <Image
-                        className="mt-[2px] h-[16px] w-[16px] cursor-pointer"
-                        src={closeRed40}
-                        alt="닫기"
-                        width={24}
-                        onClick={() => handleRemoveAddressClick(address)}
-                      />
-                    </label>
-                  </li>
-                ))}
-              </ul>
-            </div>
           </div>
-          <div className="relative mt-[24px] h-[92px] w-[350px]">
-            <p className="mb-[8px]">시작일</p>
+        </div>
+        <div className="relative mt-[24px] h-[92px] w-[350px]">
+          <p className="mb-[8px]">시작일</p>
+          <input
+            className="h-[58px] w-[350px] rounded-[6px] border border-gray-30 px-[20px] py-[16px] focus:outline-primary"
+            type={isFocused || startDate ? "datetime-local" : "text"}
+            placeholder="입력"
+            value={startDate}
+            id="startsAtGte"
+            name="startDate"
+            onChange={handleDateChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            min={minDate}
+            style={{ color: startDate ? "black" : "transparent" }}
+          />
+        </div>
+        <div className="mt-[24px] h-[92px] w-[350px] border-t-2 border-gray-10">
+          <p className="mb-[8px] mt-[24px]">금액</p>
+          <div className="relative flex">
             <input
-              className="h-[58px] w-[350px] rounded-[6px] border border-gray-30 px-[20px] py-[16px] focus:outline-primary"
-              type={isFocused || startDate ? "datetime-local" : "text"}
+              className="h-[58px] w-[169px] rounded-[6px] border border-gray-30 px-[20px] py-[16px] focus:outline-primary"
               placeholder="입력"
-              value={startDate}
-              id="startsAtGte"
-              name="startDate"
-              onChange={handleDateChange}
-              onFocus={handleFocus}
-              onBlur={handleBlur}
-              min={minDate}
-              style={{ color: startDate ? "black" : "transparent" }}
+              id="hourlyPayGte"
+              name="wage"
+              type="text"
+              value={wage}
+              onInput={handleWageChange}
             />
+            <p className="mx-[12px] my-[16px]">이상부터</p>
+            <p className="absolute left-[134px] top-[16px]">원</p>
           </div>
-          <div className="mt-[24px] h-[92px] w-[350px] border-t-2 border-gray-10">
-            <p className="mb-[8px] mt-[24px]">금액</p>
-            <div className="relative flex">
-              <input
-                className="h-[58px] w-[169px] rounded-[6px] border border-gray-30 px-[20px] py-[16px] focus:outline-primary"
-                placeholder="입력"
-                id="hourlyPayGte"
-                name="wage"
-                type="text"
-                value={wage}
-                onInput={handleWageChange}
-              />
-              <p className="mx-[12px] my-[16px]">이상부터</p>
-              <p className="absolute left-[134px] top-[16px]">원</p>
-            </div>
-          </div>
-          <div className="mt-[56px] flex h-[48px] justify-between gap-[8px]">
-            <Button
-              type="button"
-              className="w-[82px]"
-              btnColor="white"
-              onClick={handleReset}
-            >
-              초기화
-            </Button>
-            <Button
-              className="w-[260px]"
-              btnColor="orange"
-              onClick={handleApply}
-            >
-              적용하기
-            </Button>
-          </div>
+        </div>
+        <div className="mt-[56px] flex h-[48px] justify-between gap-[8px]">
+          <Button
+            type="button"
+            className="w-[82px]"
+            btnColor="white"
+            onClick={handleReset}
+          >
+            초기화
+          </Button>
+          <Button className="w-[260px]" btnColor="orange" onClick={handleApply}>
+            적용하기
+          </Button>
         </div>
       </form>
     </>

--- a/app/_apis/shop/index.ts
+++ b/app/_apis/shop/index.ts
@@ -11,11 +11,10 @@ import { isAxiosError } from "axios";
 import { API_ERROR_MESSAGE } from "@/app/_constants/error-message";
 import { getImageUrl } from "../image";
 
-
 // 가게 정보 조회
 export async function getShopDetail(shopId: string): Promise<GetShopsShopId> {
   try {
-    const res = await axiosInstance.get(`/shops/${shopId}`);
+    const res = await instance.get(`/shops/${shopId}`);
     return res.data;
   } catch (error) {
     if (isAxiosError(error)) {
@@ -129,18 +128,15 @@ export const putEditShop = async ({
     } else {
       processedImageUrl = imageUrl;
     }
-    const response = await axiosInstance.put<PutShopsShopId>(
-      `/shops/${shopId}`,
-      {
-        name,
-        category,
-        address1,
-        address2,
-        description,
-        imageUrl: processedImageUrl,
-        originalHourlyPay,
-      },
-    );
+    const response = await instance.put<PutShopsShopId>(`/shops/${shopId}`, {
+      name,
+      category,
+      address1,
+      address2,
+      description,
+      imageUrl: processedImageUrl,
+      originalHourlyPay,
+    });
     return response.status === 200;
   } catch (error) {
     if (isAxiosError(error)) {

--- a/app/_components/header/index.tsx
+++ b/app/_components/header/index.tsx
@@ -9,7 +9,7 @@ export default async function Header() {
 
   return (
     <header
-      className="fixed left-0 right-0 top-0 z-50 bg-white shadow-sm"
+      className="fixed left-0 right-0 top-0 z-30 bg-white shadow-sm"
       id="header"
     >
       <section className="grid h-[102px] grid-cols-2 grid-rows-2 px-5 pb-[10px] pt-[15px] md:flex md:h-[70px] md:px-8 md:py-[15px] lg:mx-auto lg:w-full lg:max-w-[1024px]">


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 <!-- 이슈 번호 입력 -->

- close #141 

## 🧱 작업 사항
 
- 상세필터 모바일 화면 꽉 채우기
- 피곤합니다.
- 디테일이 별로지만,
- 대충 이정도로만,
- 하죠 ㅎㅎ

## 📸 결과물

## 아이폰
![아이폰](https://github.com/902z/gheupPAY/assets/86304360/ffac6352-255e-4389-96fa-3cb8c87fdcd6)

## 갤럭시
![갤럭시](https://github.com/902z/gheupPAY/assets/86304360/6960b1a5-f6ee-4538-a0a0-bec17cb461da)



## 💬 공유 포인트 및 논의 사항
